### PR TITLE
Fixes issues with menu items breaking when to long

### DIFF
--- a/css/GroupedCmsMenu.css
+++ b/css/GroupedCmsMenu.css
@@ -1,28 +1,29 @@
 .cms-menu-list li a .toggle-children {
-	position: absolute;
-	right: 0;
-	top: 10px;
+    position: absolute;
+    right: 0;
+    top: 10px;
 }
 
 .cms-menu-list li.children > a {
-	padding-right: 30px;
+    padding-right: 30px;
 }
 
 .cms-menu-list li.children ul li a {
-	padding-left: 15px;
+    padding-left: 15px;
 }
 
 .cms-menu-list li.children li a {
-	font-size: 11px;
-	padding: 0 10px 0 40px;
-	height: 32px;
-	line-height: 32px;
+    font-size: 11px;
+    height: auto;
+    line-height: 16px;
+    min-height: 16px;
+    padding: 7px 10px 7px 40px;
 }
 
 .cms-menu-list li a .no-icon.text {
-	margin-left: 8px;
+    margin-left: 8px;
 }
 
 .cms-menu-list.collapsed li.children ul li a span.text {
-	margin-left: 30px;
+    margin-left: 30px;
 }


### PR DESCRIPTION
If menu titles are to long ( 2 lines) they break out of the box and go over other items. This fixes that issue.